### PR TITLE
Make terminal scrollbar more normal looking

### DIFF
--- a/gtk-2.0/apps/terminal.rc
+++ b/gtk-2.0/apps/terminal.rc
@@ -1,49 +1,6 @@
-style "terminal"	= "murrine-dark"
+style "terminal" = "murrine-dark"
 {
-	bg[NORMAL]	= @text_color
-	bg[ACTIVE]	= @text_color
-	bg[PRELIGHT]	= @text_color
-	bg[SELECTED]	= @text_color
-	base[NORMAL]	= @text_color
+	bg[NORMAL]	= @base_color
 }
 
-style "terminal-screen" = "murrine-dark"
-{
-	base[NORMAL]	= @text_color
-	bg[NORMAL]	= @selected_fg_color
-	bg[PRELIGHT]	= shade (0.7, @selected_fg_color)
-	TerminalScreen::background-darkness	= 0.75
-}
-
-style "terminal-scrollbar"
-{
-	engine "murrine" {
-		gradient_shades			= {2.5,2.5,2.5,2.5}
-		glowstyle			= 0
-		trough_shades	        	= { 0.1, 0.1}
-		border_shades			= { 0.1, 0.1}
-		prelight_shade			= 1.35
-		contrast			= 0.0
-	}
-}
-
-style "terminal-notebook" = "murrine-dark"
-{
-	bg[NORMAL]	= shade (0.0, @text_color_dark) # Tab background.
-	bg[ACTIVE]	= shade (0.2, @text_color_dark) # Unfocused tab background.
-	bg[PRELIGHT]	= shade (0.1, @selected_fg_color)
-	base[NORMAL]	= @text_color
-	fg[NORMAL]	= "#fff"
-	fg[ACTIVE]	= "#fff"
-	engine "murrine"
-	{
-		roundness       = 0
-		contrast        = 0.1
-		prelight_shade	= 1.5
-	}
-}
-
-class "*TerminalWindow"				style "terminal"
-#widget_class "TerminalWindow*GtkNotebook"			style "terminal-notebook"
-widget "*TerminalWindow.*.GtkVScrollbar"		style "terminal-scrollbar"
-widget "*TerminalWindow.*.TerminalScreen*"              style "terminal-screen"
+class "*TerminalWindow" style "terminal"


### PR DESCRIPTION
This seems to fix the black scrollbar in XFCE Terminal, at least for the most part.  Basically it just uses the default for the scrollbar and sets the terminal's background color which seems to show through the scrollbar's background for some reason.
