### PR TITLE
Unity Panel: blend with maximized windows

### DIFF
--- a/gtk-3.0/apps/unity.css
+++ b/gtk-3.0/apps/unity.css
@@ -1,9 +1,9 @@
 UnityPanelWidget,
 .unity-panel {
-    background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(@theme_bg_color, 1.2)),
-                                     to (shade(@theme_bg_color, 0.85)));
-    border-color: shade(@theme_bg_color, 0.8);
+		background-image: -gtk-gradient (linear, left top, left bottom,
+                                     from (shade (@theme_bg_color, 1.2)),
+                                     to (shade (@theme_bg_color, 1)));
+    border-color: shade(@theme_bg_color, 1);
     border-style: solid;
     border-width: 0px 0 1px 0px;
 }


### PR DESCRIPTION
Hello

I made a little modification to the Unity.css, in order to have the panel blend with any maximized window.
Here are a couple of examples of the final result:
-     [Maximized Chrome](http://imgur.com/YKdMX)
-     [Maximized Nautilus](http://imgur.com/dj18I)
-     [Maximized Firefox](http://imgur.com/ubopj)

Basically, I changed the panel gradient from 0.85-1.2 to 1-1.2 and the panel border color from 0.85 to 1.
The border is still there though, I figured  it looked nice to keep a little 1px spacing.

I't my first pull request, sorry if I'm not respecting any netiquette by sending it directly to you, in casae thanks for letting me know. 
I just figured it was a small change and you might be interested in it.

Best regards

/V
