### PR TITLE
Improve contrast of inactive terminal tab

### DIFF
--- a/gtk-2.0/apps/terminal.rc
+++ b/gtk-2.0/apps/terminal.rc
@@ -26,7 +26,7 @@ style "terminal-scrollbar"
 style "terminal-notebook" = "dark"
 {
 	bg[NORMAL]	= @bg_color # Tab background.
-	bg[ACTIVE]	= shade (1.03, @bg_color) # Unfocused tab background.
+	bg[ACTIVE]	= shade (0.70, @bg_color) # Unfocused tab background.
 	fg[ACTIVE]	= shade (0.86, @bg_color)
 	base[NORMAL]	= @text_color
 	engine "murrine"


### PR DESCRIPTION
Inactive terminal tab is 3% lighter than active (currently). This is indistinguishable and very frustrating. I've changed it to 30% darker (what it was before).

Fixes #15

xoxo @ngauthier
