### PR TITLE
The blue highlight color used by Greybird doesn't harmonize with its grey theme. 

### DIFF
--- a/gtk-2.0/gtkrc
+++ b/gtk-2.0/gtkrc
@@ -3,7 +3,7 @@
 # based on "Bluebird" by Simon Steinbeiß and Pasi Lallinaho
 # Description: As is the original theme, this theme is 100% free and open source.
 
-gtk_color_scheme	= "bg_color:#CECECE\nselected_bg_color:#398ee7\nbase_color:#fcfcfc" # Background, base.
+gtk_color_scheme	= "bg_color:#CECECE\nselected_bg_color:#909090\nbase_color:#fcfcfc" # Background, base.
 gtk_color_scheme	= "fg_color:#3C3C3C\nselected_fg_color:#ffffff\ntext_color:#000000" # Foreground, text. 
 gtk_color_scheme	= "tooltip_bg_color:#000000\ntooltip_fg_color:#E1E1E1" # Tooltips.
 gtk_color_scheme	= "link_color:#2c82dd" # Hyperlinks

--- a/gtk-3.0/settings.ini
+++ b/gtk-3.0/settings.ini
@@ -1,4 +1,4 @@
 [Settings]
-gtk-color-scheme = "base_color:#fcfcfc\nbg_color:#cecece\ntooltip_bg_color:#000000\nselected_bg_color:#398ee7\ntext_color:#000000\nfg_color:#3c3c3c\ntooltip_fg_color:#e1e1e1\nselected_fg_color:#ffffff\nlink_color:#2c82dd"
+gtk-color-scheme = "base_color:#fcfcfc\nbg_color:#cecece\ntooltip_bg_color:#000000\nselected_bg_color:#909090\ntext_color:#000000\nfg_color:#3c3c3c\ntooltip_fg_color:#e1e1e1\nselected_fg_color:#ffffff\nlink_color:#2c82dd"
 gtk-auto-mnemonics = 1
 gtk-visible-focus = automatic


### PR DESCRIPTION
This commit changes the text selection color to grey (#909090) which looks a lot better, IMHO, and fits in better with the Greybird theme.
