### PR TITLE
Match padding of gtk2 buttons in Xfce panel.

### DIFF
--- a/gtk-3.0/apps/xfce.css
+++ b/gtk-3.0/apps/xfce.css
@@ -11,6 +11,7 @@ XfceHeading {
 
 .xfce4-panel .button {
     border-radius: 0;
+    padding: 1;
 }
 
 .xfce4-panel .button:active {


### PR DESCRIPTION
Currently padding is 4px horizontal, 2px vertical, which conflicts with other plugins using Gtk2+Greybird.
