### PR TITLE
Fix white font foreground color on Debian with Xfce.

### DIFF
--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -622,6 +622,19 @@ GtkComboBox.combobox-entry .button:insensitive {
     border-radius: 0;
 }
 
+/**********
+ * window *
+ **********/
+GtkWindow {
+    color: @fg_color;
+}
+
+* {
+    /* inherit the color from parent by default */
+    color: inherit;
+    background-color: @bg_color;
+}
+
 /*******************
  * scrolled window *
  *******************/


### PR DESCRIPTION
Some applications on Debian with Xfce (e.g. Tranmission) were drawn with white font on grey/silver background.
