### PR TITLE
fix checkboxes and radios in gtk3.14

### DIFF
--- a/gtk-3.0/gtk-widgets-assets.css
+++ b/gtk-3.0/gtk-widgets-assets.css
@@ -5,144 +5,144 @@
 .check,
 .check row:selected,
 .check row:selected:focus {
-    background-image: url("assets/checkbox-unchecked.png");
+    -gtk-icon-source: url("assets/checkbox-unchecked.png");
 }
 
 .check:insensitive,
 .check row:selected:insensitive,
 .check row:selected:focus:insensitive {
-    background-image: url("assets/checkbox-unchecked-insensitive.png");
+    -gtk-icon-source: url("assets/checkbox-unchecked-insensitive.png");
 }
 
-.check:active,
-.check row:selected:active,
-.check row:selected:focus:active {
-    background-image: url("assets/checkbox-checked.png");
+.check:active, .check:checked,
+.check row:selected:active, .check row:selected:checked,
+.check row:selected:focus:active, .check row:selected:focus:checked {
+    -gtk-icon-source: url("assets/checkbox-checked.png");
 }
 
-.check:active:hover,
-.check row:selected:active:hover,
-.check row:selected:focus:active:hover {
-    background-image: url("assets/checkbox-checked-hover.png");
+.check:active:hover, .check:checked:hover,
+.check row:selected:active:hover, .check row:selected:checked:hover,
+.check row:selected:focus:active:hover, .check row:selected:focus:checked:hover {
+    -gtk-icon-source: url("assets/checkbox-checked-hover.png");
 }
 
-.check:active:insensitive,
-.check row:selected:active:insensitive,
-.check row:selected:focus:active:insensitive {
-    background-image: url("assets/checkbox-checked-insensitive.png");
+.check:active:insensitive, .check:checked:insensitive,
+.check row:selected:active:insensitive, .check row:selected:checked:insensitive,
+.check row:selected:focus:active:insensitive, .check row:selected:focus:checked:insensitive {
+    -gtk-icon-source: url("assets/checkbox-checked-insensitive.png");
 }
 
 .check:inconsistent,
 .check row:selected:inconsistent,
 .check row:selected:focus:inconsistent {
-    background-image: url("assets/checkbox-mixed.png");
+    -gtk-icon-source: url("assets/checkbox-mixed.png");
 }
 
 .check:inconsistent:hover,
 .check row:selected:inconsistent:hover,
 .check row:selected:focus:inconsistent:hover {
-    background-image: url("assets/checkbox-mixed-hover.png");
+    -gtk-icon-source: url("assets/checkbox-mixed-hover.png");
 }
 
 .check:inconsistent:insensitive,
 .check row:selected:inconsistent:insensitive,
 .check row:selected:focus:inconsistent:insensitive {
-    background-image: url("assets/checkbox-mixed-insensitive.png");
+    -gtk-icon-source: url("assets/checkbox-mixed-insensitive.png");
 }
 
 .radio,
 .radio row:selected,
 .radio row:selected:focus {
-    background-image: url("assets/radio-unselected.png");
+    -gtk-icon-source: url("assets/radio-unselected.png");
 }
 
 .radio:insensitive,
 .radio row:selected:insensitive,
 .radio row:selected:focus:insensitive {
-    background-image: url("assets/radio-unselected-insensitive.png");
+    -gtk-icon-source: url("assets/radio-unselected-insensitive.png");
 }
 
-.radio:active,
-.radio row:selected:active,
-.radio row:selected:focus:active {
-    background-image: url("assets/radio-selected.png");
+.radio:active, .radio:checked,
+.radio row:selected:active, .radio row:selected:checked,
+.radio row:selected:focus:active, .radio row:selected:focus:checked {
+    -gtk-icon-source: url("assets/radio-selected.png");
 }
 
-.radio:active:hover,
-.radio row:selected:active:hover,
-.radio row:selected:focus:active:hover {
-    background-image: url("assets/radio-selected-hover.png");
+.radio:active:hover, .radio:checked:hover,
+.radio row:selected:active:hover, .radio row:selected:checked:hover,
+.radio row:selected:focus:active:hover, .radio row:selected:focus:checked:hover {
+    -gtk-icon-source: url("assets/radio-selected-hover.png");
 }
 
-.radio:active:insensitive,
-.radio row:selected:active:insensitive,
-.radio row:selected:focus:active:insensitive {
-    background-image: url("assets/radio-selected-insensitive.png");
+.radio:active:insensitive, .radio:checked:insensitive,
+.radio row:selected:active:insensitive, .radio row:selected:checked:insensitive,
+.radio row:selected:focus:active:insensitive, .radio row:selected:focus:checked:insensitive {
+    -gtk-icon-source: url("assets/radio-selected-insensitive.png");
 }
 
 .radio:inconsistent,
 .radio row:selected:inconsistent,
 .radio row:selected:focus:inconsistent {
-    background-image: url("assets/radio-mixed.png");
+    -gtk-icon-source: url("assets/radio-mixed.png");
 }
 
 .radio:inconsistent:hover,
 .radio row:selected:inconsistent:hover,
 .radio row:selected:focus:inconsistent:hover {
-    background-image: url("assets/radio-mixed-hover.png");
+    -gtk-icon-source: url("assets/radio-mixed-hover.png");
 }
 
 .radio:inconsistent:insensitive,
 .radio row:selected:inconsistent:insensitive,
 .radio row:selected:focus:inconsistent:insensitive {
-    background-image: url("assets/radio-mixed-insensitive.png");
+    -gtk-icon-source: url("assets/radio-mixed-insensitive.png");
 }
 
-.menuitem.check:active {
-    background-image: url("assets/menuitem-checkbox-checked.png");
+.menuitem.check:active, .menuitem.check:checked {
+    -gtk-icon-source: url("assets/menuitem-checkbox-checked.png");
 }
 
-.menuitem.check:active:hover {
-    background-image: url("assets/menuitem-checkbox-checked-hover.png");
+.menuitem.check:active:hover, .menuitem.check:checked:hover {
+    -gtk-icon-source: url("assets/menuitem-checkbox-checked-hover.png");
 }
 
-.menuitem.check:active:insensitive {
-    background-image: url("assets/menuitem-checkbox-checked-insensitive.png");
+.menuitem.check:active:insensitive, .menuitem.check:checked:insensitive {
+    -gtk-icon-source: url("assets/menuitem-checkbox-checked-insensitive.png");
 }
 
 .menuitem.check:inconsistent:hover,
 .menuitem.radio:inconsistent:hover {
-    background-image: url("assets/menuitem-checkbox-mixed-hover.png");
+    -gtk-icon-source: url("assets/menuitem-checkbox-mixed-hover.png");
 }
 
 .menuitem.check:inconsistent,
 .menuitem.radio:inconsistent {
-    background-image: url("assets/menuitem-checkbox-mixed.png");
+    -gtk-icon-source: url("assets/menuitem-checkbox-mixed.png");
 }
 
 .menuitem.check:inconsistent:insensitive,
 .menuitem.radio:inconsistent:insensitive {
-    background-image: url("assets/menuitem-checkbox-mixed-insensitive.png");
+    -gtk-icon-source: url("assets/menuitem-checkbox-mixed-insensitive.png");
 }
 
-.menuitem.radio:active {
-    background-image: url("assets/menuitem-radio-checked.png");
+.menuitem.radio:active, .menuitem.radio:checked {
+    -gtk-icon-source: url("assets/menuitem-radio-checked.png");
 }
 
-.menuitem.radio:active:hover {
-    background-image: url("assets/menuitem-radio-checked-hover.png");
+.menuitem.radio:active:hover, .menuitem.radio:checked:hover {
+    -gtk-icon-source: url("assets/menuitem-radio-checked-hover.png");
 }
 
-.menuitem.radio:active:insensitive {
-    background-image: url("assets/menuitem-radio-checked-insensitive.png");
+.menuitem.radio:active:insensitive, .menuitem.radio:checked:insensitive {
+    -gtk-icon-source: url("assets/menuitem-radio-checked-insensitive.png");
 }
 
 GtkIconView.content-view.cell.check {
-    background-image: url("assets/grid-selection-unchecked.png");
+    -gtk-icon-source: url("assets/grid-selection-unchecked.png");
 }
 
-GtkIconView.content-view.cell.check:active {
-    background-image: url("assets/grid-selection-checked.png");
+GtkIconView.content-view.cell.check:active, GtkIconView.content-view.cell.check:checked {
+    -gtk-icon-source: url("assets/grid-selection-checked.png");
 }
 
 /***************


### PR DESCRIPTION
This fixes theme in gtk3.14 (checkboxes and radio buttons are not displaying). Fix should be backward compatible (hopefully -gtk-icon-source can be used in older versions too), but I didn't test that.
