### PR TITLE
Fix disabled menu item text color in Chrome

### DIFF
--- a/gtk-2.0/gtkrc
+++ b/gtk-2.0/gtkrc
@@ -298,7 +298,7 @@ style "menu"
 	text[PRELIGHT]    = @base_color
 	text[SELECTED]    = @base_color
 	text[ACTIVE]      = @fg_color
-	text[INSENSITIVE] = @text_color
+	text[INSENSITIVE] = mix (0.4, @fg_color, @bg_color)
 	
 	engine "murrine" 
 	{


### PR DESCRIPTION
I've been having this issue in Chrome for a while, I don't actually remember when it started. But hopefully this will fix it and not affect anything else negatively (so far, nothing that I've found in xfce 4.12).

Text of disabled or unavailable entries in menus in Google Chrome currently look like this, with no way to distinguish them from the other (enabled) entries at first glance. Note the lack of bg color when hovering over it, too:
![screenshot 2015-05-07 14 21 41](https://cloud.githubusercontent.com/assets/794031/7524083/4ab404fc-f4c5-11e4-8823-4af85f65ff23.png)

With this change applied, these disabled entries now look like this:
![screenshot 2015-05-07 14 22 19](https://cloud.githubusercontent.com/assets/794031/7524089/5188b476-f4c5-11e4-9266-1bc98b5f9ee2.png)
