### PR TITLE
fix invalid selector for GtkComboBox

### DIFF
--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -2146,7 +2146,7 @@ GtkComboBox .separator {
 .sidebar .view row:selected:focus,
 .sidebar-row:selected,
 .sidebar-row:selected:hover,
-.sidebar-row:selected:focus, {
+.sidebar-row:selected:focus {
     border-width: 1px 0;
     border-style: solid;
     border-top-color: shade(@theme_bg_color, 0.85);


### PR DESCRIPTION
this was pulled with latest changes.

At least on gtk 3.18 it causes unrecoverable parser error and blocks style loading completely.