### PR TITLE
Plank theme for Greybird

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,6 +42,7 @@ install-data-hook:
 	cp    $(srcdir)/index.theme		$(DESTDIR)$(themedir)
 	cp    $(srcdir)/ubiquity-panel-bg.png	$(DESTDIR)$(themedir)
 	cp    $(srcdir)/Greybird.emerald	$(DESTDIR)$(themedir)
+	cp    $(srcdir)/plank			$(DESTDIR)$(themedir)
 
 uninstall-hook:
 	test -e $(DESTDIR)$(themedir) && rm -rfv $(DESTDIR)$(themedir)

--- a/plank/dock.theme
+++ b/plank/dock.theme
@@ -1,0 +1,34 @@
+# Based on the Jupiter Redux theme by Cassidy James
+# http://cassidyjames.deviantart.com/art/Jupiter-Redux-Formerly-Pantheon-theme-for-Plank-213303421
+[PlankTheme]
+TopRoundness=6
+BottomRoundness=0
+LineWidth=1
+OuterStrokeColor=25;;25;;25;;204
+FillStartColor=36;;36;;36;;204
+FillEndColor=36;;36;;36;;204
+InnerStrokeColor=36;;36;;36;;204
+
+[PlankDockTheme]
+HorizPadding=1.5
+TopPadding=1.5
+BottomPadding=2
+ItemPadding=2
+IndicatorSize=5
+IconShadowSize=1
+UrgentBounceHeight=1.6666666666666667
+LaunchBounceHeight=0.625
+FadeOpacity=1
+ClickTime=300
+UrgentBounceTime=600
+LaunchBounceTime=600
+ActiveTime=300
+SlideTime=300
+FadeTime=200
+HideTime=150
+GlowSize=30
+GlowTime=10000
+GlowPulseTime=2000
+UrgentHueShift=150
+ItemMoveTime=450
+CascadeHide=true


### PR DESCRIPTION
This adds a native theme for Plank when using the "Gtk+" theme.

This theme is based on Jupiter Redux by Cassidy James (http://cassidyjames.deviantart.com/art/Jupiter-Redux-Formerly-Pantheon-theme-for-Plank-213303421)

I adjusted the appearance to more closely align with Greybird and Xubuntu defaults, basing colors and transparency on the panel and corner radius on the xfce4-notifyd theme.

![screenshot_2016-09-07_20-57-05](https://cloud.githubusercontent.com/assets/1894517/18333507/a8d7f97c-753d-11e6-8db4-794953efee79.png)
