### PR TITLE
Fix ConversationListView in Geary (GTK 3.20+)

### DIFF
--- a/gtk-3.0/_gnome-apps.scss
+++ b/gtk-3.0/_gnome-apps.scss
@@ -43,3 +43,15 @@ $variant: 'light';
         &.dnd { border-style: none; }
     }
 }
+
+/*********
+ * Geary *
+ *********/
+.conversation-frame .view.cell {
+    background-color: $base_color;
+}
+
+.conversation-frame .view.cell:selected,
+.conversation-frame .view.cell:selected:focus {
+    background-color: $selected_bg_color;
+}

--- a/gtk-3.0/gtk-contained.css
+++ b/gtk-3.0/gtk-contained.css
@@ -4507,6 +4507,17 @@ read if you used those and something break with a version upgrade you're on your
   .nautilus-list-view .view.dnd, .nautilus-list-view iconview.dnd {
     border-style: none; }
 
+/*********
+ * Geary *
+ *********/
+.conversation-frame .view.cell, .conversation-frame iconview.cell {
+  background-color: #fcfcfc; }
+
+.conversation-frame .view.cell:selected, .conversation-frame iconview.cell:selected,
+.conversation-frame .view.cell:selected:focus,
+.conversation-frame iconview.cell:selected:focus {
+  background-color: #398ee7; }
+
 UnityDecoration {
   -UnityDecoration-extents: 28px 1px 1px 1px;
   -UnityDecoration-input-extents: 10px;


### PR DESCRIPTION
This change improves the appearance of the ConversationListView in Geary with GTK 3.20+

**Before**
![screenshot_2016-12-10_18-07-47](https://cloud.githubusercontent.com/assets/1894517/21077107/080bd03a-bf0d-11e6-9ebb-715c3c7ea1cd.png)

**After**
![screenshot_2016-12-10_19-15-07](https://cloud.githubusercontent.com/assets/1894517/21077108/133bd54a-bf0d-11e6-9321-dc582416135c.png)
