### PR TITLE
Create gnome-shell.css

### DIFF
--- a/gnome-shell/gnome-shell.css
+++ b/gnome-shell/gnome-shell.css
@@ -1,0 +1,7 @@
+@import url("/usr/share/gnome-shell/theme/gnome-shell.css");
+
+/* Panel */
+
+#panel {
+    background-color: rgba(36, 36, 36, 0.8);
+}

--- a/gnome-shell/gnome-shell.css
+++ b/gnome-shell/gnome-shell.css
@@ -1,7 +1,9 @@
-@import url("/usr/share/gnome-shell/theme/gnome-shell.css");
-
 /* Panel */
 
 #panel {
     background-color: rgba(36, 36, 36, 0.8);
+}
+
+#panel .panel-corner {
+    -panel-corner-radius: 0;
 }


### PR DESCRIPTION
Set the gnome-shell panel background to the same background color that Greybird use for the Plank theme.

This is how gnome-shell normally looks.
![image](https://cloud.githubusercontent.com/assets/10222521/25680982/f3e1ea42-3052-11e7-8238-59ea1dca48bb.png)

This is how it looks after with this theme applied.
![image](https://cloud.githubusercontent.com/assets/10222521/25680997/03221072-3053-11e7-9d88-d8a75281b662.png)
