### PR TITLE
Change `librsvg-2-devel` to `librsvg2-devel`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Debian or Ubuntu:
 
 Fedora:
 
-`dnf install gdk-pixbuf2-devel librsvg-2-devel rubygem-sass`
+`dnf install gdk-pixbuf2-devel librsvg2-devel rubygem-sass`
 
 ### Install without admin privileges
 


### PR DESCRIPTION
The package name has changed to `librsvg2-devel` in Fedora (updates) repository.