### PR TITLE
Prevent tab borders from colliding with containing widget if show_border = false  (Fixes #228)

### DIFF
--- a/gtk-3.0/_common.scss
+++ b/gtk-3.0/_common.scss
@@ -2039,6 +2039,8 @@ notebook {
   &.frame {
     border-style: none;
 
+    > header { margin-left: 0; }
+
     > stack:not(:only-child) { // the :not(:only-child) is for "hidden" notebooks
       border: 1px solid shade($bg_color, 0.9);
     }
@@ -2302,6 +2304,13 @@ notebook {
     &.right > tabs {
       margin-left: -2px;
     }
+  }
+
+  // if the notebook property show_border is set to false, the frame directly inside the notebook
+  // doesn't exist, so we define the tab margins, the background and backdrop colors here:
+
+  > header {
+    margin-left: 6px;
   }
 
   > stack:not(:only-child) { // the :not(:only-child) is for "hidden" notebooks

--- a/gtk-3.0/_common.scss
+++ b/gtk-3.0/_common.scss
@@ -2315,7 +2315,7 @@ notebook {
 
   > stack:not(:only-child) { // the :not(:only-child) is for "hidden" notebooks
     background-color: shade($bg_color, 1.05);
-    border-width: 1px;
+    border-width: 1px 0 0;
     border-color: shade($bg_color, 0.9);
     border-style: solid;
     &:backdrop { background-color: $backdrop_bg_color; }

--- a/gtk-3.0/gtk-contained-dark.css
+++ b/gtk-3.0/gtk-contained-dark.css
@@ -2360,6 +2360,9 @@ notebook.frame {
   notebook.frame > stack:not(:only-child) {
     border: 1px solid shade(#393f3f, 0.9); }
 
+notebook.frame > header {
+  margin-left: 0; }
+
 notebook > header {
   padding: 1px;
   background-color: #393f3f; }
@@ -2531,6 +2534,9 @@ notebook > header {
     margin-right: -2px; }
   notebook > header.right > tabs {
     margin-left: -2px; }
+
+notebook > header {
+  margin-left: 6px; }
 
 notebook > stack:not(:only-child) {
   background-color: shade(#393f3f, 1.05);

--- a/gtk-3.0/gtk-contained.css
+++ b/gtk-3.0/gtk-contained.css
@@ -2374,6 +2374,9 @@ notebook.frame {
   notebook.frame > stack:not(:only-child) {
     border: 1px solid shade(#cecece, 0.9); }
 
+notebook.frame > header {
+  margin-left: 0; }
+
 notebook > header {
   padding: 1px;
   background-color: #cecece; }
@@ -2545,6 +2548,9 @@ notebook > header {
     margin-right: -2px; }
   notebook > header.right > tabs {
     margin-left: -2px; }
+
+notebook > header {
+  margin-left: 6px; }
 
 notebook > stack:not(:only-child) {
   background-color: shade(#cecece, 1.05);


### PR DESCRIPTION
The core idea of show_border = false is to get rid of the border around
the widget and set the margins to zero to visually embed the widget
directly inside the containing widget, without introducing additional
borders.

To facilitate such design choices by applications, Greybird's tabs need
to be slightly moved to the right to prevent them from colliding with
the containing widget's borders.

A screenshot of how this looks in Greybird and other themes is supplied
in #228.