### PR TITLE
Fix the huge default margins in GTK+3 statusbar

### DIFF
--- a/gtk-3.0/_common.scss
+++ b/gtk-3.0/_common.scss
@@ -1327,6 +1327,15 @@ searchbar,
 
 
 /***************
+ * Status bars *
+ ***************/
+statusbar {
+  $statusbar-margin: 2px;
+  margin: ($statusbar-margin - 6) ($statusbar-margin - 10);
+}
+
+
+/***************
  * Header bars *
  ***************/
 %titlebar,


### PR DESCRIPTION
This is hardcoded in the UI file:
https://github.com/GNOME/gtk/blob/gtk-3-22/gtk/ui/gtkstatusbar.ui#L6

So the default margins have to be subtracted from the desired margin.

This is inspired by how the Canta theme fixes it:
https://github.com/vinceliuice/Canta-theme/blob/db96a1e27e131e4a0fad1e7e2b656179db46b5e8/src/_sass/gtk/apps/_mate.scss#L286

The large size results in various bug reports and issues like:
https://bugs.eclipse.org/bugs/show_bug.cgi?id=456345
https://github.com/zim-desktop-wiki/zim-desktop-wiki/issues/342
https://github.com/geany/geany/issues/1825
https://unix.stackexchange.com/questions/271042/gtk3-statusbar-height

And C-based fixes like:
https://git.xfce.org/apps/ristretto/commit/?id=289329

I've read that this has been fixed in Cinnamon and Unity themes, presumably in a similar fashion, but I don't have any of those to test.

It seems like a bad fix for every individual application to be forcing the margins to zero in C code, which is why I made this PR here. At least it would fix all XFCE apps with the default theme.

**NOTE:** This isn't tested, I don't know much about SASS, and I'm not sure that `2px` is the best value, I just wanted to see if something could be done about the large status bar.