### PR TITLE
Fix size of linked button with images in header bar

### DIFF
--- a/gtk-3.0/_common.scss
+++ b/gtk-3.0/_common.scss
@@ -1530,7 +1530,7 @@ headerbar {
   }
   button:not(.image-button):not(.titlebutton) image {
     min-width: 28px;
-    min-height: 28px;
+    min-height: 24px;
   }
   button.image-button {
     min-width: 28px;

--- a/gtk-3.0/gtk-contained-dark.css
+++ b/gtk-3.0/gtk-contained-dark.css
@@ -1983,7 +1983,7 @@ headerbar button.titlebutton image {
 
 headerbar button:not(.image-button):not(.titlebutton) image {
   min-width: 28px;
-  min-height: 28px; }
+  min-height: 24px; }
 
 headerbar button.image-button {
   min-width: 28px;

--- a/gtk-3.0/gtk-contained.css
+++ b/gtk-3.0/gtk-contained.css
@@ -1991,7 +1991,7 @@ headerbar button.titlebutton image {
 
 headerbar button:not(.image-button):not(.titlebutton) image {
   min-width: 28px;
-  min-height: 28px; }
+  min-height: 24px; }
 
 headerbar button.image-button {
   min-width: 28px;


### PR DESCRIPTION
I noticed this problem with [Gtranslator](https://wiki.gnome.org/Apps/Gtranslator), but this sample can be used to reproduce the issue: https://gist.github.com/andreldm/828370955dfb22e4c55204c49b6ea52b

**Before**
![before](https://user-images.githubusercontent.com/599565/67151282-4a7b7100-f29a-11e9-9ea2-d975a7445532.png)

**After**
![after](https://user-images.githubusercontent.com/599565/67151283-4d766180-f29a-11e9-90ff-078a558fa416.png)


