### PR TITLE
Properly fix size of linked button with images in header bar

### DIFF
--- a/gtk-3.0/_common.scss
+++ b/gtk-3.0/_common.scss
@@ -1530,7 +1530,7 @@ headerbar {
   }
   button:not(.image-button):not(.titlebutton) image {
     min-width: 28px;
-    min-height: 24px;
+    min-height: 28px;
   }
   button.image-button {
     min-width: 28px;

--- a/gtk-3.0/_common.scss
+++ b/gtk-3.0/_common.scss
@@ -1524,6 +1524,10 @@ headerbar {
     margin-top: 3px;
     margin-bottom: 3px;
   }
+  button label {
+    min-width: 28px;
+    min-height: 28px;
+  }
   button.titlebutton image {
     min-width: 22px;
     min-height: 22px;

--- a/gtk-3.0/gtk-contained-dark.css
+++ b/gtk-3.0/gtk-contained-dark.css
@@ -1983,7 +1983,7 @@ headerbar button.titlebutton image {
 
 headerbar button:not(.image-button):not(.titlebutton) image {
   min-width: 28px;
-  min-height: 24px; }
+  min-height: 28px; }
 
 headerbar button.image-button {
   min-width: 28px;

--- a/gtk-3.0/gtk-contained-dark.css
+++ b/gtk-3.0/gtk-contained-dark.css
@@ -1977,6 +1977,10 @@ headerbar button {
   margin-top: 3px;
   margin-bottom: 3px; }
 
+headerbar button label {
+  min-width: 28px;
+  min-height: 28px; }
+
 headerbar button.titlebutton image {
   min-width: 22px;
   min-height: 22px; }

--- a/gtk-3.0/gtk-contained.css
+++ b/gtk-3.0/gtk-contained.css
@@ -1991,7 +1991,7 @@ headerbar button.titlebutton image {
 
 headerbar button:not(.image-button):not(.titlebutton) image {
   min-width: 28px;
-  min-height: 24px; }
+  min-height: 28px; }
 
 headerbar button.image-button {
   min-width: 28px;

--- a/gtk-3.0/gtk-contained.css
+++ b/gtk-3.0/gtk-contained.css
@@ -1985,6 +1985,10 @@ headerbar button {
   margin-top: 3px;
   margin-bottom: 3px; }
 
+headerbar button label {
+  min-width: 28px;
+  min-height: 28px; }
+
 headerbar button.titlebutton image {
   min-width: 22px;
   min-height: 22px; }


### PR DESCRIPTION
I noticed that my previous fix was wrong, so this is follow-up to properly fix the problem.

**Before**
![before](https://user-images.githubusercontent.com/599565/67152203-faa3a680-f2a7-11e9-9e7d-978dd01cb15f.png)

**After**
![after](https://user-images.githubusercontent.com/599565/67152205-fecfc400-f2a7-11e9-8472-a17876c6c02c.png)

P.S. I kinda like smaller buttons, if you agree I can try to work on that.