### PR TITLE
WIP: Slimmer headerbar and buttons

### DIFF
--- a/dark/gtk-3.0/_common.scss
+++ b/dark/gtk-3.0/_common.scss
@@ -1516,29 +1516,36 @@ headerbar {
 }
 
 headerbar {
+  min-height: 24px;
+
   // add vertical margins to common widget on the headerbar to avoid them spanning the whole height
   entry,
-  spinbutton,
-  separator,
-  button {
+  separator {
     margin-top: 3px;
     margin-bottom: 3px;
   }
+  spinbutton,
+  button {
+    margin-top: 2px;
+    margin-bottom: 2px;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
   button label {
     min-width: 28px;
-    min-height: 28px;
+    min-height: 20px;
   }
   button.titlebutton image {
     min-width: 22px;
-    min-height: 22px;
+    min-height: 20px;
   }
   button:not(.image-button):not(.titlebutton) image {
     min-width: 28px;
-    min-height: 28px;
+    min-height: 20px;
   }
   button.image-button {
     min-width: 28px;
-    min-height: 28px;
+    min-height: 20px;
     padding-left: 2px;
     padding-right: 2px;
   }

--- a/light/gtk-3.0/_common.scss
+++ b/light/gtk-3.0/_common.scss
@@ -1516,29 +1516,36 @@ headerbar {
 }
 
 headerbar {
+  min-height: 24px;
+
   // add vertical margins to common widget on the headerbar to avoid them spanning the whole height
-  entry,
-  spinbutton,
-  separator,
-  button {
-    margin-top: 3px;
-    margin-bottom: 3px;
-  }
+entry,
+separator {
+  margin-top: 3px;
+  margin-bottom: 3px;
+}
+spinbutton,
+button {
+  margin-top: 2px;
+  margin-bottom: 2px;
+  padding-top: 0;
+  padding-bottom: 0;
+}
   button label {
     min-width: 28px;
-    min-height: 28px;
+    min-height: 20px;
   }
   button.titlebutton image {
     min-width: 22px;
-    min-height: 22px;
+    min-height: 20px;
   }
   button:not(.image-button):not(.titlebutton) image {
     min-width: 28px;
-    min-height: 28px;
+    min-height: 20px;
   }
   button.image-button {
     min-width: 28px;
-    min-height: 28px;
+    min-height: 20px;
     padding-left: 2px;
     padding-right: 2px;
   }


### PR DESCRIPTION
I am kinda satisfied with the results I got here, however they are far from perfect because unfortunately many applications have buttons/widgets with `valign` set to `GTK_ALIGN_FILL` so they are larger than they should:
![Screenshot_2019-11-01_00-53-13](https://user-images.githubusercontent.com/599565/68001263-2298ef80-fc42-11e9-828f-60dd847a4c8d.png)

Where the expected result is:
![Screenshot_2019-11-01_00-54-05](https://user-images.githubusercontent.com/599565/68001276-2f1d4800-fc42-11e9-8cb6-797d41998b72.png)

I don't know if this can be fixed by the theme.

P.S. I also tried to reduce the radius of the top-left and top-right corners, I changed it from 7px to 3px, in some apps the corners are glitched, increasing to 5px fixes the problem for those apps but the glitch appears in other apps.