### PR TITLE
Fix GTK3 dark colors

### DIFF
--- a/light/gtk-3.0/_colors.scss
+++ b/light/gtk-3.0/_colors.scss
@@ -2,9 +2,9 @@
 // it gets @if ed depending on $variant
 
 
-$base_color: if($variant == 'light', #fcfcfc, #292929);
+$base_color: if($variant == 'light', #fcfcfc, #2d2e30);
 $text_color: if($variant == 'light', #212121, white);
-$bg_color: if($variant == 'light', #cecece, #393f3f);
+$bg_color: if($variant == 'light', #cecece, #3b3e3f);
 $fg_color: if($variant == 'light', #3c3c3c, #eeeeec);
 
 $selected_fg_color: #ffffff;


### PR DESCRIPTION
The GTK 3.0 version of Greybird-dark has slightly different colors than the xfwm4 version: the dark window color does not match the titlebar.

This has already been fixed in Greybird-Geeko, so this is mainly a backport of its adjustments: https://github.com/shimmerproject/Greybird-Geeko/commit/2b93a31cbcc0757bd342f145a856ad4675c78f10 

![fix](https://user-images.githubusercontent.com/238631/80399960-5f286980-88ba-11ea-8129-1c8336d948e5.png)
