### PR TITLE
Correct gradients for horizontal scrollbars

### DIFF
--- a/light/gtk-3.0/_common.scss
+++ b/light/gtk-3.0/_common.scss
@@ -2502,10 +2502,44 @@ scrollbar {
     -GtkScrollbar-has-forward-stepper: false;
   }
 
-  background-image: linear-gradient(to right,
-                                    lighten($bg_color, 10%),
-                                    lighten($bg_color, 30%)
-                                    );
+  &.vertical {
+    background-image: linear-gradient(to right,
+                                      lighten($bg_color, 10%),
+                                      lighten($bg_color, 30%)
+                                      );
+
+    slider {
+      background-image: linear-gradient(to right,
+                                        lighten($scrollbar_slider_color, 5%),
+                                        lighten($scrollbar_slider_color, 1%));
+
+      &:hover {
+        background-image: linear-gradient(to right,
+                                          darken($scrollbar_slider_color, 5%),
+                                          darken($scrollbar_slider_color, 1%));
+      }
+    }
+  }
+
+  &.horizontal {
+    background-image: linear-gradient(to bottom,
+                                      lighten($bg_color, 10%),
+                                      lighten($bg_color, 30%)
+                                      );
+
+    slider {
+      background-image: linear-gradient(to bottom,
+                                        lighten($scrollbar_slider_color, 5%),
+                                        lighten($scrollbar_slider_color, 1%));
+
+      &:hover {
+        background-image: linear-gradient(to bottom,
+                                          darken($scrollbar_slider_color, 5%),
+                                          darken($scrollbar_slider_color, 1%));
+      }
+    }
+  }
+
   transition: 300ms $ease-out-quad;
 
   // scrollbar border
@@ -2528,15 +2562,8 @@ scrollbar {
     border: 1px solid darken($bg_color, 30%);
     border-radius: 10px;
     background-clip: padding-box;
-    background-image: linear-gradient(to right,
-                                      lighten($scrollbar_slider_color, 5%),
-                                      lighten($scrollbar_slider_color, 1%));
 
-    &:hover {
-      background-image: linear-gradient(to right,
-                                        darken($scrollbar_slider_color, 5%),
-                                        darken($scrollbar_slider_color, 1%));
-    }
+
 
     &:hover:active { background-color: $scrollbar_slider_active_color; }
 


### PR DESCRIPTION
I noticed that horizontal and vertical scrollbars are both colored with horizontal gradients, which causes the vertical scrollbars to have a raised 3d appearance, while the horizontal scrollbars appear smooth.

This PR changes the horizontal scrollbars to use vertical gradients, so both types of scrollbar appear the same.

#### Before:
![before](https://user-images.githubusercontent.com/1455481/100704258-cf283200-336a-11eb-8e3f-7aff23f4fdae.png)
#### After:
![after](https://user-images.githubusercontent.com/1455481/100704293-e0713e80-336a-11eb-88cf-6dd4afee2231.png)


