### PR TITLE
Fixed XFCE 4.12 panel font color (#269)

### DIFF
--- a/dark/gtk-2.0/apps/xfce-panel.rc
+++ b/dark/gtk-2.0/apps/xfce-panel.rc
@@ -8,15 +8,15 @@ style "theme-panel" = "dark"
 	bg[PRELIGHT]	= shade (0.85, @selected_bg_color)
 	bg[SELECTED]	= @selected_bg_color
 
-	fg[NORMAL]	= shade (0.9, @base_color)
-	fg[PRELIGHT]	= @base_color
-	fg[ACTIVE]	= shade (0.9, @base_color)
-	fg[SELECTED]	= shade (0.9, @base_color)
+	fg[NORMAL]	= shade (0.9, @panel_fg)
+	fg[PRELIGHT]	= @panel_fg
+	fg[ACTIVE]	= shade (0.9, @panel_fg)
+	fg[SELECTED]	= shade (0.9, @panel_fg)
 
-	text[NORMAL]	= shade (0.9, @base_color)
-	text[PRELIGHT]	= @base_color
-	text[ACTIVE]	= shade (0.9, @base_color)
-	text[SELECTED]	= shade (0.9, @base_color)
+	text[NORMAL]	= shade (0.9, @panel_fg)
+	text[PRELIGHT]	= @panel_fg
+	text[ACTIVE]	= shade (0.9, @panel_fg)
+	text[SELECTED]	= shade (0.9, @panel_fg)
 
 	engine "murrine" {
 		roundness	= 0
@@ -29,13 +29,13 @@ style "theme-panel" = "dark"
 
 style "theme-panel-text"
 {
-	fg[NORMAL]	= @base_color
+	fg[NORMAL]	= @panel_fg
 	fg[PRELIGHT]	= "#ffffff"
-	fg[ACTIVE]	= @base_color
+	fg[ACTIVE]	= @panel_fg
 
-	text[NORMAL]	= @base_color
+	text[NORMAL]	= @panel_fg
 	text[PRELIGHT]	= "#ffffff"
-	text[ACTIVE]	= @base_color
+	text[ACTIVE]	= @panel_fg
 
 	engine "murrine" {
 		textstyle	= 1
@@ -80,9 +80,9 @@ style "window-buttons" = "theme-panel"
 	bg[PRELIGHT]	= shade (0.85, @selected_bg_color)
 	bg[SELECTED]	= shade (0.85, @selected_bg_color)
 
-	fg[NORMAL]	= shade (0.7, @base_color)
-	fg[ACTIVE]	= @base_color
-	fg[PRELIGHT]	= @base_color
+	fg[NORMAL]	= shade (0.7, @panel_fg)
+	fg[ACTIVE]	= @panel_fg
+	fg[PRELIGHT]	= @panel_fg
 
 	engine "murrine" {
 		contrast = 0.0

--- a/dark/gtk-2.0/gtkrc
+++ b/dark/gtk-2.0/gtkrc
@@ -7,7 +7,7 @@ gtk-color-scheme	= "bg_color:#3b3e3f\nselected_bg_color:#398ee7\nbase_color:#2d2
 gtk-color-scheme	= "fg_color:#eeeeec\nselected_fg_color:#ffffff\ntext_color:#ffffff" # Foreground, text.
 gtk-color-scheme	= "tooltip_bg_color:#000000\ntooltip_fg_color:#E1E1E1" # Tooltips.
 gtk-color-scheme	= "link_color:#35b9ab" # Hyperlinks
-gtk-color-scheme	= "panel_bg:#686868" # Panel bg color
+gtk-color-scheme	= "panel_bg:#686868\npanel_fg:#ffffff" # Panel color
 gtk-color-scheme	= "fm_color:#F7F7F7" # Color used in Nautilus and Thunar.
 gtk-color-scheme	= "bg_color_dark:#686868\ntext_color_dark:#FFF"
 


### PR DESCRIPTION
Fixed issue with XFCE panel font color on distros that use XFCE 4.12 (like Debian 10 Stable)