### PR TITLE
Bugfix: removed background color for non-bg items

### DIFF
--- a/light/gtk-3.0/_common.scss
+++ b/light/gtk-3.0/_common.scss
@@ -4512,8 +4512,6 @@ headerbar.selection-mode button.titlebutton,
 
     &:backdrop {
       color: $backdrop_selected_fg_color;
-      background-color: $backdrop_selected_bg_color;
-
       &:disabled { color: mix($backdrop_selected_fg_color, $selected_bg_color, 30%); }
     }
   }

--- a/light/gtk-3.0/_common.scss
+++ b/light/gtk-3.0/_common.scss
@@ -3670,7 +3670,7 @@ row {
       &.has-open-popup,
       &:hover { background-color: mix($fg_color, $selected_bg_color, 10%); }
 
-      &:backdrop { background-color: $selected_bg_color; }
+      @extend %selected_items;
     }
   }
 


### PR DESCRIPTION
There's was bug in the last commit: Widgets, that should not have a bg color would now have one under certain circumstances. This fix solves the problem.