### PR TITLE
Fixes: Removed BG-color of non-BG-color items, added backdrop color to GtkListBox and GtkLabel

### DIFF
--- a/light/gtk-3.0/_common.scss
+++ b/light/gtk-3.0/_common.scss
@@ -3673,12 +3673,12 @@ row {
     &:backdrop:hover { background-color: transparent; }
 
     &:selected {
+      @extend %selected_items;
+      
       &:active { box-shadow: inset 0 2px 3px -1px transparentize(black, 0.5); }
 
       &.has-open-popup,
       &:hover { background-color: mix($fg_color, $selected_bg_color, 10%); }
-
-      @extend %selected_items;
     }
   }
 

--- a/light/gtk-3.0/_common.scss
+++ b/light/gtk-3.0/_common.scss
@@ -4512,8 +4512,6 @@ headerbar.selection-mode button.titlebutton,
 
     &:backdrop {
       color: $backdrop_selected_fg_color;
-      background-color: $backdrop_selected_bg_color;
-
       &:disabled { color: mix($backdrop_selected_fg_color, $selected_bg_color, 30%); }
     }
   }

--- a/light/gtk-3.0/_common.scss
+++ b/light/gtk-3.0/_common.scss
@@ -3670,7 +3670,7 @@ row {
       &.has-open-popup,
       &:hover { background-color: mix($fg_color, $selected_bg_color, 10%); }
 
-      &:backdrop { background-color: $selected_bg_color; }
+      @extend %selected_items;
     }
   }
 

--- a/light/gtk-3.0/_common.scss
+++ b/light/gtk-3.0/_common.scss
@@ -179,7 +179,6 @@ label {
   row:selected &,
   &:selected { @extend %nobg_selected_items; }
 
-
   &:disabled {
     color: $insensitive_fg_color;
 

--- a/light/gtk-3.0/_common.scss
+++ b/light/gtk-3.0/_common.scss
@@ -179,6 +179,7 @@ label {
   row:selected &,
   &:selected { @extend %nobg_selected_items; }
 
+
   &:disabled {
     color: $insensitive_fg_color;
 
@@ -191,6 +192,13 @@ label {
     }
 
     selection { @extend %selected_items:disabled; }
+  }
+
+  // Special case for selections in labels.
+  // (because `selection:backdrop` does not apply)
+  &:backdrop selection {
+    color: $backdrop_selected_fg_color;
+    background-color: $backdrop_selected_bg_color;
   }
 }
 

--- a/light/gtk-3.0/_common.scss
+++ b/light/gtk-3.0/_common.scss
@@ -3674,7 +3674,7 @@ row {
 
     &:selected {
       @extend %selected_items;
-      
+
       &:active { box-shadow: inset 0 2px 3px -1px transparentize(black, 0.5); }
 
       &.has-open-popup,


### PR DESCRIPTION
This is an extension of my previous PR [here](https://github.com/shimmerproject/Greybird/pull/305#pullrequestreview-767867813)

I will make "active" selections grey, if the window looses its focus.

It contains three fixes:

# Fix 1 removed BG-color of non-BG-color items

Some widgets, that should not have a bg color now have one if `selected` and `backdrop`ped. In gtk3-widget-factory you can see it on page 3:
![image](https://user-images.githubusercontent.com/46980694/135367186-8f312816-03c3-45b8-8b81-e252d253f5a5.png)

# Fix 2 `GtkListBox` rows now have a gray selected backdrop color. 
In gtk3-widget-factory you can see it on page 3:
![image](https://user-images.githubusercontent.com/46980694/135467648-297d286a-aace-4482-9aee-a92499d92377.png)

# Fix 3 `GtkLabel` now have a gray selected backdrop color. 

(self-explanatory)