### PR TITLE
Hide top frame when "Hide frame when maximized" is seleted in settings

### DIFF
--- a/dark/xfwm4-a11y/themerc
+++ b/dark/xfwm4-a11y/themerc
@@ -24,3 +24,4 @@ shadow_opacity=50
 
 maximized_offset=3
 show_app_icon=false
+frame_border_top=1

--- a/dark/xfwm4-compact/themerc
+++ b/dark/xfwm4-compact/themerc
@@ -20,3 +20,4 @@ shadow_delta_width=0
 shadow_delta_x=0
 shadow_delta_y=-8
 shadow_opacity=50
+frame_border_top=1

--- a/dark/xfwm4/themerc
+++ b/dark/xfwm4/themerc
@@ -23,3 +23,4 @@ shadow_delta_width=0
 shadow_delta_x=0
 shadow_delta_y=-10
 shadow_opacity=50
+frame_border_top=1

--- a/light/xfwm4-a11y/themerc
+++ b/light/xfwm4-a11y/themerc
@@ -26,3 +26,4 @@ shadow_opacity=50
 
 maximized_offset=3
 show_app_icon=false
+frame_border_top=1

--- a/light/xfwm4-compact/themerc
+++ b/light/xfwm4-compact/themerc
@@ -20,3 +20,4 @@ shadow_delta_width=0
 shadow_delta_x=0
 shadow_delta_y=-8
 shadow_opacity=50
+frame_border_top=1

--- a/light/xfwm4/themerc
+++ b/light/xfwm4/themerc
@@ -22,3 +22,4 @@ shadow_delta_width=0
 shadow_delta_x=0
 shadow_delta_y=-10
 shadow_opacity=50
+frame_border_top=1


### PR DESCRIPTION
Xfwm4 added the ability to crop maximized top borders in commit [bf41e461](https://gitlab.xfce.org/xfce/xfwm4/-/commit/bf41e461abe520d20cf2022e697cd38bc28867e8).

This change will hide the top frame when maximized if the
option is checked in xfwm4-tweaks-settings -- if it is not checked
this change has no effect).



~~This may be a bug in xfwm4. If so let me know and I will open an issue there.
They set the default value to 0 in xfwm4 but in their own themes always use a
value above 0 so maybe they missed it or maybe they intended it.
Regardless, Greybird isn't working correctly without it.~~

