### PR TITLE
Style `item` menubar nodes for GTK 4

### DIFF
--- a/light/gtk-4.0/_common.scss
+++ b/light/gtk-4.0/_common.scss
@@ -2158,6 +2158,7 @@ menubar,
 
   &:backdrop { background-color: $backdrop_bg_color; }
 
+  > item,
   > menuitem {
     min-height: 16px;
     padding: 3px 8px;


### PR DESCRIPTION
Per https://docs.gtk.org/gtk4/class.PopoverMenuBar.html

Fixes: #328