### PR TITLE
Stop forcing icon style for sidebars

### DIFF
--- a/light/gtk-3.0/_common.scss
+++ b/light/gtk-3.0/_common.scss
@@ -3844,7 +3844,6 @@ filechooserbutton:drop(active) {
 .sidebar {
   border-style: none;
   background-color: $sidebar_bg_color;
-  -gtk-icon-style: regular;
 
   row,
   treeview {

--- a/light/gtk-4.0/_common.scss
+++ b/light/gtk-4.0/_common.scss
@@ -3958,7 +3958,6 @@ filechooserbutton:drop(active) {
 .sidebar {
   border-style: none;
   background-color: $sidebar_bg_color;
-  -gtk-icon-style: regular;
 
   row,
   treeview,


### PR DESCRIPTION
The sidebar property `-gtk-icon-style: regular` was forcing regular icons even if apps requested symbolic icons and the icon theme provided them.

Removing it now allows Thunar to use a symbolic eject icon. It also allows Nemo and Rhythmbox to use symbolic icons. It improves the look and readability when using the dark theme.

For reference, this line was previously added in 0cd4db5