### PR TITLE
Fix label styles for xfdesktop 4.19

### DIFF
--- a/dark/gtk-3.0/_xfce.scss
+++ b/dark/gtk-3.0/_xfce.scss
@@ -164,7 +164,7 @@ XfdesktopIconView.view {
   color: $panel_fg_color;
   border-radius: 3px;
   &:active {
-    background-color: rgba(darken($selected_bg_color, 20%), 0.5);
+    background-color: rgba(darken($selected_bg_color, 15%), 0.5);
     color: $selected_bg_color;
     text-shadow: 0 1px 1px black;
   }
@@ -178,8 +178,11 @@ XfdesktopIconView.view {
       color: $selected_fg_color;
       background-color: transparent;
     }
-    &:selected, &:selected:backdrop {
-      background-color: rgba(darken($selected_bg_color, 20%), 0.5);
+    &:selected {
+      background-color: lighten($selected_bg_color, 20%);
+    }
+    &:selected:backdrop {
+      background-color: rgba($selected_bg_color, 0.5);
     }
   }
   .rubberband {

--- a/dark/gtk-3.0/_xfce.scss
+++ b/dark/gtk-3.0/_xfce.scss
@@ -164,18 +164,22 @@ XfdesktopIconView.view {
   color: $panel_fg_color;
   border-radius: 3px;
   &:active {
-    background: rgba(darken($selected_bg_color, 15%), 0.5);
-    text-shadow: 0 1px 1px black;
-  }
-  &:active {
-    background: rgba(darken($selected_bg_color, 15%), 0.5);
+    background-color: rgba(darken($selected_bg_color, 20%), 0.5);
     color: $selected_bg_color;
     text-shadow: 0 1px 1px black;
   }
   .label {
     text-shadow: 1px 1px 2px black;
+    outline-style: none;
     &:active {
+        color: $selected_fg_color;
+    }
+    &:backdrop {
       color: $selected_fg_color;
+      background-color: transparent;
+    }
+    &:selected, &:selected:backdrop {
+      background-color: rgba(darken($selected_bg_color, 20%), 0.5);
     }
   }
   .rubberband {

--- a/light/gtk-3.0/_xfce.scss
+++ b/light/gtk-3.0/_xfce.scss
@@ -177,8 +177,11 @@ XfdesktopIconView.view {
       color: $selected_fg_color;
       background-color: transparent;
     }
-    &:selected, &:selected:backdrop {
-      background-color: rgba(darken($selected_bg_color, 20%), 0.5);
+    &:selected {
+      background-color: darken($selected_bg_color, 20%);
+    }
+    &:selected:backdrop {
+      background-color: rgba($selected_bg_color, 0.5);
     }
   }
   .rubberband {

--- a/light/gtk-3.0/_xfce.scss
+++ b/light/gtk-3.0/_xfce.scss
@@ -163,14 +163,22 @@ XfdesktopIconView.view {
   color: $panel_fg_color;
   border-radius: 3px;
   &:active {
-    background: rgba(darken($selected_bg_color, 15%), 0.5);
+    background: rgba(darken($selected_bg_color, 20%), 0.5);
     color: $selected_bg_color;
     text-shadow: 0 1px 1px black;
   }
   .label {
     text-shadow: 1px 1px 2px black;
+    outline-style: none;
     &:active {
       color: $selected_fg_color;
+    }
+    &:backdrop {
+      color: $selected_fg_color;
+      background-color: transparent;
+    }
+    &:selected, &:selected:backdrop {
+      background-color: rgba(darken($selected_bg_color, 20%), 0.5);
     }
   }
   .rubberband {


### PR DESCRIPTION
Xfdesktop from git master (54f5e219)

| | Light      | Dark |
| ---| ----------- | ----------- |
| Before | ![image](https://github.com/shimmerproject/Greybird/assets/599565/60571742-dcca-4dd7-a734-3b0181a8db01) | ![image](https://github.com/shimmerproject/Greybird/assets/599565/7687c345-e487-47a8-9392-a8b5ab89a544) |
| After| ![image](https://github.com/shimmerproject/Greybird/assets/599565/869a9425-c147-4d6b-878e-aea228b83793) | ![image](https://github.com/shimmerproject/Greybird/assets/599565/889807be-2bbe-472f-834d-81c1f58099f2) |