### PR TITLE
thunar: Selected sidepane item when disabled should not stand out

### DIFF
--- a/dark/gtk-3.0/_xfce.scss
+++ b/dark/gtk-3.0/_xfce.scss
@@ -146,7 +146,6 @@ wnck-pager {
   &:hover { background-color: $selected_bg_color; }
 }
 
-/* Thunar's sidebar top border */
 .thunar {
   :backdrop { color: $insensitive_fg_color; }
   toolbar {
@@ -156,7 +155,10 @@ wnck-pager {
 
     entry { min-height: 24px; }
   }
-  .sidebar.frame { border-top: 1px solid $borders_color; }
+  .sidebar {
+    &.frame { border-top: 1px solid $borders_color; }
+    .view:selected:backdrop { color: $insensitive_fg_color; }
+  }
 }
 
 XfdesktopIconView.view {

--- a/light/gtk-3.0/_xfce.scss
+++ b/light/gtk-3.0/_xfce.scss
@@ -147,7 +147,6 @@ wnck-pager {
   &:hover { background-color: $selected_bg_color; }
 }
 
-/* Thunar's sidebar top border */
 .thunar {
   grid :backdrop { color: $insensitive_fg_color; }
   toolbar {
@@ -155,7 +154,10 @@ wnck-pager {
 
     entry { min-height: 24px; }
   }
-  .sidebar.frame { border-top: 1px solid $borders_color; }
+  .sidebar {
+    &.frame { border-top: 1px solid $borders_color; }
+    .view:selected:backdrop { color: $insensitive_fg_color; }
+  }
 }
 
 XfdesktopIconView.view {


### PR DESCRIPTION
When Thunar is not focused, the selected item in the sidepane is not grayed out, this is not really perceptible because only the label text remains black-ish, when symbolic icons (new feature, behind a hidden toggle) are used this glitch is more prominent.

This PR fixes only Thunar's sidepane, 1. because I couldn't make this a generic style adjustment in `_commons.scss`, 2. because I'm afraid it could cause regressions.

The icon theme used in the screenshots below is Papirus.

| | Before | After |
| ------------- | ------------- | ------------- |
| Regular Icons 16px | ![image](https://github.com/shimmerproject/Greybird/assets/599565/16080bf6-1035-444c-b545-03e00285b534) | ![image](https://github.com/shimmerproject/Greybird/assets/599565/aa09eff6-3986-48d1-8423-f841d1e39ef3) |
| Regular Icons 32px | ![image](https://github.com/shimmerproject/Greybird/assets/599565/3fd094a8-f834-4a7a-b162-80381e3848e3) | ![image](https://github.com/shimmerproject/Greybird/assets/599565/f52ba73d-c2eb-4f81-b0cf-3b78e9cbdfbb) |
| Symbolic Icons 16px | ![image](https://github.com/shimmerproject/Greybird/assets/599565/6cd93394-f3d7-4550-91c8-7d26258b0049) | ![image](https://github.com/shimmerproject/Greybird/assets/599565/b6a7c0d5-2ce4-4095-9317-7d31d261639d) |
| Symbolic Icons 32px | ![image](https://github.com/shimmerproject/Greybird/assets/599565/ff705ff8-ff82-4104-b3fe-460e5ae3a567) | ![image](https://github.com/shimmerproject/Greybird/assets/599565/29dda32a-afdc-4bc2-8127-7303f7fe7667) |